### PR TITLE
ci: Codecov integration & Travis upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 os: linux
-dist: focal
+dist: bionic
 language: php
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 ---
 os: linux
-dist: bionic
+dist: focal
 language: php
 
 branches:
   only:
     - master
-    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^(v)?\d+\.\d+(\.\d+)?(-\S*)?$/
 
 git:
   depth: 10
@@ -17,9 +17,12 @@ env:
     - XDEBUG_MODE=coverage
 
 jobs:
+  fast_finish: true
+  allow_failures:
+    - php: 8.0
   include:
     - &STANDARD_TEST_JOB
-      stage: "Code style & static code analysis"
+      stage: "Code style, lint and unit-tests"
       php: 7.3
       install:
         - (composer self-update; true)
@@ -28,12 +31,17 @@ jobs:
         - export TRAVIS_PULL_REQUEST TRAVIS_COMMIT_RANGE
         - ./dev-tools/php-cs-check.sh
         - composer check:analyse
+        - composer check:test
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -s ./build/
+
     - &STANDART_UNIT_TEST_JOB
       <<: *STANDARD_TEST_JOB
-      stage: "Unit tests"
-      php: 7.3
+      stage: "Unit tests other php versions"
+      php: 7.4
       script:
         - composer check:test
+
     -
       <<: *STANDART_UNIT_TEST_JOB
-      php: 7.4
+      php: 8.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Composer Library Skeleton
 =========================
 [![Travis Build Status](https://travis-ci.com/webarchitect609/composer-library-skeleton.svg?branch=master)](https://travis-ci.com/webarchitect609/composer-library-skeleton)
+[![codecov](https://codecov.io/gh/webarchitect609/composer-library-skeleton/branch/master/graph/badge.svg?token=N8K5K8V88E)](https://codecov.io/gh/webarchitect609/composer-library-skeleton)
+[![PHP version](https://img.shields.io/packagist/php-v/webarchitect609/composer-library-skeleton)](https://www.php.net/supported-versions.php)
 [![Latest version](https://img.shields.io/github/v/tag/webarchitect609/composer-library-skeleton?sort=semver)](https://github.com/webarchitect609/composer-library-skeleton/releases)
 [![Downloads](https://img.shields.io/packagist/dt/webarchitect609/composer-library-skeleton)](https://packagist.org/packages/webarchitect609/composer-library-skeleton)
-[![PHP version](https://img.shields.io/packagist/php-v/webarchitect609/composer-library-skeleton)](https://www.php.net/supported-versions.php)
 [![License](https://img.shields.io/github/license/webarchitect609/composer-library-skeleton)](LICENSE.md)
-[![More stuff from me](https://img.shields.io/badge/packagist-webarchitect609-blueviolet)](https://packagist.org/packages/webarchitect609/)
 
 **Please, be careful:** disclaimer text example goes here!
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.3"
+    "php": "^7.3 || 8.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -9,20 +11,18 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
-    <testsuites>
-        <testsuite name="All Test Suites">
-            <directory>src/test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/main</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+  <coverage>
+    <include>
+      <directory suffix=".php">src/main</directory>
+    </include>
+    <report>
+      <html outputDirectory="build/coverage"/>
+      <clover outputFile="build/coverage.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="All Test Suites">
+      <directory>src/test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
- use Codecov to show code coverage with the badge;
- universal branch excluding pattern for semver tags with 'v' or
  without;
- introduce support of php 8.0, but allow it to fail;
- optimize build time by running Unit test at the same stage with CS and
  lint;
- enable fast finish;
- upgrade dist: Ubuntu Bionic 18.04 -> Ubuntu Focal 20.04;
- re-arrange badges and remove excessive.